### PR TITLE
Use hosted tarball

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gsd" %}
 {% set version = "1.4.0" %}
-{% set sha256 = "8a86c2dec59a8da7c350437f49457dd21fbb4fa2e267d7c4944723f92b577e8b" %}
+{% set sha256 = "198926d1a0a3d62c4a0f304073612c70564d3755c80348ca1b26ca73314a747b" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gsd" %}
 {% set version = "1.4.0" %}
-{% set sha256 = "ba212674d7bfcdf8913751d03bcfc3a14e8efe85e45d6b11a670d33a62467b05" %}
+{% set sha256 = "8a86c2dec59a8da7c350437f49457dd21fbb4fa2e267d7c4944723f92b577e8b" %}
 
 package:
   name: {{ name|lower }}
@@ -8,11 +8,11 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://bitbucket.org/glotzer/{{ name }}/get/v{{ version }}.tar.gz
+  url: https://glotzerlab.engin.umich.edu/Downloads/{{ name }}/{{ name }}-v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script: python setup.py install --single-version-externally-managed --record record.txt
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gsd" %}
-{% set version = "1.4.0" %}
-{% set sha256 = "198926d1a0a3d62c4a0f304073612c70564d3755c80348ca1b26ca73314a747b" %}
+{% set version = "1.5.0" %}
+{% set sha256 = "bd0ffcbdeba9e1a4c70c420867416edf9400e20aa348bac8a5d5cbcf27419166" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   script: python setup.py install --single-version-externally-managed --record record.txt
 


### PR DESCRIPTION
Use tarballs hosted on a webserver to avoid issues where hashes change on the bitbucket generated tarball.